### PR TITLE
add Actions workflow for training

### DIFF
--- a/.github/workflows/train.yml
+++ b/.github/workflows/train.yml
@@ -1,0 +1,43 @@
+name: Train and publish model
+
+# This workflow is triggered manually. To run it, click the "Actions" tab on the repo page.
+on: workflow_dispatch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install replicate
+
+      - name: Train model
+        env:
+          # Find this at https://replicate.com/account
+          REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}
+        run: |
+          python train.py
+
+      - name: Install Cog
+        run: |
+          sudo curl -o /usr/local/bin/cog -L https://github.com/replicate/cog/releases/latest/download/cog_`uname -s`_`uname -m`
+          sudo chmod +x /usr/local/bin/cog
+
+      - name: Log in to Replicate
+        env:
+          # Find this at https://replicate.com/auth/token
+          REPLICATE_CLI_TOKEN: ${{ secrets.REPLICATE_CLI_TOKEN }}
+        run: |
+          echo $REPLICATE_CLI_TOKEN | cog login --token-stdin
+
+      - name: Push to Replicate
+        run: |
+          echo "TODO"
+          # cog push

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,7 @@
+# Data
+
+This directory is for training data.
+
+Add 3-5 images ot this directory before kicking off the Actions workflow.
+
+TODO: Document the correct file formats, dimensions, etc.

--- a/train.py
+++ b/train.py
@@ -1,0 +1,44 @@
+import os
+import replicate
+import json
+import mimetypes
+import zipfile
+
+# TODO: set this to the new DreamBooth training model
+MODEL_NAME = "replicate/hello-world"
+MODEL_VERSION = "5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa"
+
+def train():
+  print("Training model...")
+
+  # TODO: uncomment this check
+  # print("Checking training data")
+  # # count files in the data directory by guessing mime type
+  # image_count = 0
+  # for file in os.listdir("data"):
+  #   if mimetypes.guess_type(file)[0].startswith("image/"):
+  #     image_count += 1  
+  
+  # if image_count == 0:
+  #   raise Exception("No images found in data directory")
+
+  print("Zipping training data")
+  with zipfile.ZipFile("data.zip", "w") as zip:
+    for file in os.listdir("data"):
+      zip.write(os.path.join("data", file))
+
+  print(f"Training on Replicate using model {MODEL_NAME}@{MODEL_VERSION}")
+  print(f"https://replicate.com/{MODEL_NAME}/versions/{MODEL_VERSION}")
+  model = replicate.models.get(MODEL_NAME)
+  version = model.versions.get(MODEL_VERSION)
+
+  # TODO: use data.zip as input
+  return version.predict(text="GitHub Actions")
+
+
+if __name__ == "__main__":
+    output = train()
+    print("Done training. Output:")
+    print(json.dumps(output))
+
+    # TODO: download generated weights


### PR DESCRIPTION
This PR fleshes out an Actions workflow and Python training script for creating a trained DreamBooth model from a directory of images. The workflow can be triggered manually in the GitHub UI.

What it does:

1. Set up Python
1. Install Python dependencies
1. Train model
1. Install Cog
1. Log in to Replicate
1. Push to Replicate

Opening this as a draft here for convenience and visibility, but we'll probably want this to live in a different repo that will serve as a template repo for users to fork/copy. Something like `replicate/dreambooth`.

Note: I created my own fork instead of a branch on the canonical repo because `workflow_dispatch` only works against the main branch.

If anyone wants to grab this and run with it over the weekend, feel free. Otherwise I'll pick it up next week.