### PR TITLE
extract instance data zipfile as a flat directory

### DIFF
--- a/predictor.py
+++ b/predictor.py
@@ -1,5 +1,6 @@
 import os
 import gc
+import mimetypes
 import shutil
 import tempfile
 from zipfile import ZipFile
@@ -206,8 +207,10 @@ class Predictor(BasePredictor):
             for zip_info in zip_ref.infolist():
                 if zip_info.filename[-1] == '/':
                     continue
-                zip_info.filename = os.path.basename(zip_info.filename)
-                zip_ref.extract(zip_info, cog_instance_data)
+                mt = mimetypes.guess_type(zip_info.filename)
+                if mt and mt[0] and mt[0].startswith('image/'):
+                    zip_info.filename = os.path.basename(zip_info.filename)
+                    zip_ref.extract(zip_info, cog_instance_data)
 
         if class_data is not None:
             with ZipFile(str(class_data), "r") as zip_ref:

--- a/predictor.py
+++ b/predictor.py
@@ -201,8 +201,13 @@ class Predictor(BasePredictor):
                 shutil.rmtree(path)
             os.makedirs(path)
 
+        # extract zip contents, flattening any paths present within it
         with ZipFile(str(instance_data), "r") as zip_ref:
-            zip_ref.extractall(cog_instance_data)
+            for zip_info in zip_ref.infolist():
+                if zip_info.filename[-1] == '/':
+                    continue
+                zip_info.filename = os.path.basename(zip_info.filename)
+                zip_ref.extract(zip_info, cog_instance_data)
 
         if class_data is not None:
             with ZipFile(str(class_data), "r") as zip_ref:
@@ -214,7 +219,7 @@ class Predictor(BasePredictor):
             "pretrained_vae_name_or_path": "stabilityai/sd-vae-ft-mse",
             "revision": "fp16",
             "tokenizer_name": None,
-            "instance_data_dir": f"{cog_instance_data}/data",
+            "instance_data_dir": f"{cog_instance_data}",
             "class_data_dir": f"{cog_class_data}/class_data",
             "instance_prompt": instance_prompt,
             "class_prompt": class_prompt,


### PR DESCRIPTION
The predictor currently expects the `instance_data` zip file to have a `data/` directory within it.

This PR updates the predictor to accept a zip file with any directory structure, and extract its files to a flat directory.

| Zip path | Extracted path |
--- | ---
foo.jpg | foo.jpg
data/bar.jpg | bar.jpg
data/wombo/baz.png | baz.png