### PR TITLE
link to API blog post from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # DreamBooth
 
-✋ Notice: This is an experimental model in early development. ✋
-
 From Wikipedia:
 
 > DreamBooth is a deep learning generation model used to fine-tune existing text-to-image models, developed by researchers from Google Research and Boston University in 2022. Originally developed using Google's own Imagen text-to-image model, DreamBooth implementations can be applied to other text-to-image models, where it can allow the model to generate more fine-tuned and personalised outputs after training on three to five images of a subject.
@@ -14,7 +12,7 @@ This repository is a copy of the [canonical DreamBooth code](https://github.com/
 
 This model takes your training images as input, and outputs trained weights that can be used to publish your own custom variant of Stable Diffusion.
 
-To get started training and publishing your own custom model, see [github.com/replicate/dreambooth-template](https://github.com/replicate/dreambooth-template)
+We built an API that simplifies the process of using this model. **To get started training and publishing your own custom model, see [replicate.com/blog/dreambooth-api](https://replicate.com/blog/dreambooth-api).**
 
 The default stable diffusion model used is `runwayml/stable-diffusion-v1-5` (fp16), and `stabilityai/sd-vae-ft-mse` as `pretrained_vae`. 
 


### PR DESCRIPTION
This model is the underlying mechanism for training DreamBooth models, but it's probably not the thing most users actually need to look at. This PR updates the README to link link people to the blog post to get started.

https://replicate.com/blog/dreambooth-api