### PR TITLE
expand descriptions for primary inputs

### DIFF
--- a/predictor.py
+++ b/predictor.py
@@ -60,16 +60,16 @@ class Predictor(BasePredictor):
         #     default=None,
         # ),
         instance_prompt: str = Input(
-            description="The prompt with identifier specifying the instance",
+            description="The prompt you use to describe your training images, in the format: `a [identifier] [class noun]`, where the `[identifier]` should be a rare token. Relatively short sequences with 1-3 letters work the best (e.g. `sks`, `xjy`). `[class noun]` is a coarse class descriptor of the subject (e.g. cat, dog, watch, etc.). For example, your `instance_prompt` can be: `a sks dog`, or with some extra description `a photo of a sks dog`. The trained model will learn to bind a unique identifier with your specific subject in the `instance_data`.",
         ),
         class_prompt: str = Input(
-            description="The prompt to specify images in the same class as provided instance images.",
+            description="The prompt or description of the coarse class of your training images, in the format of `a [class noun]`, optionally with some extra description. `class_prompt` is used to alleviate overfitting to your customised images (the trained model should still keep the learnt prior so that it can still generate different dogs when the `[identifier]` is not in the prompt). Corresponding to the examples of the `instant_prompt` above, the `class_prompt` can be `a dog` or `a photo of a dog`.",
         ),
         instance_data: Path = Input(
-            description="A ZIP file containing the training data of instance images",
+            description="A ZIP file containing your training images (JPG, PNG, etc. size not restricted). These images contain your 'subject' that you want the trained model to embed in the output domain for later generating customized scenes beyond the training images. For best results, use images without noise or unrelated objects in the background.",
         ),
         class_data: Path = Input(
-            description="A ZIP file containing the training data of class images. Images will be generated if you do not provide.",
+            description="An optional ZIP file containing the training data of class images. This corresponds to `class_prompt` above, also with the purpose of keeping the model generalizable. By default, the pretrained stable-diffusion model will generate N images (determined by the `num_class_images` you set) based on the `class_prompt` provided. But to save time or to have your preferred specific set of `class_data`, you can also provide them in a ZIP file.",
             default=None,
         ),
         num_class_images: int = Input(


### PR DESCRIPTION
This PR updates the inputs in the Cog predictor to include more detailed descriptions for `instance_prompt`, `class_prompt`, `instance_data`, and `class_data`.

These extended descriptions are derived from the descriptions @chenxwh added to the model README.

I'm suggesting moving them into the predictor because:

- They'll display alongside the form inputs on the Replicate website, exactly where users of the model need to see them.
- They'll display in the API documentation for the model, too
- We are planning to overhaul the replicate/dreambooth model's README to be more of a high-level tutorial about how to train a model, and I don't want this important and detailed information to get lost in that README refactor.

Related: https://github.com/replicate/replicate-web/issues/2712